### PR TITLE
Epic/upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ AppRegistry.registerComponent('example', () => example);
 | deletePath(id) | Delete a path with its `id` |
 | save(imageType, transparent, folder, filename, includeImage, cropToImageSize) | Save image to camera roll or filesystem. If `localSourceImage` is set and a background image is loaded successfully, set `includeImage` to true to include background image and set `cropToImageSize` to true to crop output image to background image.<br/>Android: Save image in `imageType` format with transparent background (if `transparent` sets to True) to **/sdcard/Pictures/`folder`/`filename`** (which is Environment.DIRECTORY_PICTURES).<br/>iOS: Save image in `imageType` format with transparent background (if `transparent` sets to True) to camera roll or file system. If `folder` and `filename` are set, image will save to **temporary directory/`folder`/`filename`** (which is NSTemporaryDirectory())  |
 | getPaths() | Get the paths that drawn on the canvas |
-| getBase64(imageType, transparent, includeImage, cropToImageSize, callback) | Get the base64 of image and receive data in callback function, which called with 2 arguments. First one is error (null if no error) and second one is base64 result. |
+| getBase64(imageType, transparent, includeImage, includeText, cropToImageSize, callback) | Get the base64 of image and receive data in callback function, which called with 2 arguments. First one is error (null if no error) and second one is base64 result. |
 
 #### Constants
 -------------

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ export interface SavePreference {
 }
 
 export interface LocalSourceImage {
-  path: string
+  filename: string
   directory?: string
   mode?: 'AspectFill' | 'AspectFit' | 'ScaleToFill'
 }

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -246,7 +246,6 @@
         [data drawInContext:_drawingContext];
         [self setFrozenImageNeedsUpdate];
         [self setNeedsDisplay];
-        [self notifyPathsUpdate];
     }
 }
 
@@ -287,6 +286,7 @@
         [_currentPath drawInContext:_drawingContext];
     }
     _currentPath = nil;
+    [self notifyPathsUpdate];
 }
 
 - (void) clear {

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -39,6 +39,13 @@
     return self;
 }
 
+- (void)dealloc {
+    CGContextRelease(_drawingContext);
+    _drawingContext = nil;
+    CGImageRelease(_frozenImage);
+    _frozenImage = nil;
+}
+
 - (void)drawRect:(CGRect)rect {
     CGContextRef context = UIGraphicsGetCurrentContext();
 

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -438,11 +438,9 @@
 }
 
 - (void)notifyPathsUpdate {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (_onChange) {
-            _onChange(@{ @"pathsUpdate": @(_paths.count) });
-        }
-    });
+    if (_onChange) {
+        _onChange(@{ @"pathsUpdate": @(_paths.count) });
+    }
 }
 
 @end

--- a/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
+++ b/ios/RNSketchCanvas/RNSketchCanvas/RNSketchCanvas.m
@@ -438,9 +438,11 @@
 }
 
 - (void)notifyPathsUpdate {
-    if (_onChange) {
-        _onChange(@{ @"pathsUpdate": @(_paths.count) });
-    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (_onChange) {
+            _onChange(@{ @"pathsUpdate": @(_paths.count) });
+        }
+    });
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/terrylinla/react-native-sketch-canvas"
   },
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "react-native-sketch-canvas allows you to draw / sketch on both iOS and Android devices and sync the drawing data between users. Of course you can save as image.",
   "author": "Terry Lin",
   "main": "index.js",

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -106,7 +106,7 @@ class SketchCanvas extends React.Component {
   clear() {
     this._paths = []
     this._path = null
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.clear, [])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.clear, [])
   }
 
   undo() {
@@ -123,7 +123,7 @@ class SketchCanvas extends React.Component {
         const coor = p.split(',').map(pp => parseFloat(pp).toFixed(2))
         return `${coor[0] * this._screenScale * this._size.width / data.size.width},${coor[1] * this._screenScale * this._size.height / data.size.height}`;
       })
-      UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPath, [
+      UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.addPath, [
         data.path.id, processColor(data.path.color), data.path.width * this._screenScale, pathData
       ])
     } else {
@@ -133,11 +133,11 @@ class SketchCanvas extends React.Component {
 
   deletePath(id) {
     this._paths = this._paths.filter(p => p.path.id !== id)
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.deletePath, [id])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.deletePath, [id])
   }
 
   save(imageType, transparent, folder, filename, includeImage, includeText, cropToImageSize) {
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.save, [imageType, folder, filename, transparent, includeImage, includeText, cropToImageSize])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.save, [imageType, folder, filename, transparent, includeImage, includeText, cropToImageSize])
   }
 
   getPaths() {
@@ -168,10 +168,10 @@ class SketchCanvas extends React.Component {
           id: parseInt(Math.random() * 100000000), color: this.props.strokeColor,
           width: this.props.strokeWidth, data: []
         }
-        
+
         UIManager.dispatchViewManagerCommand(
           this._handle,
-          UIManager.RNSketchCanvas.Commands.newPath,
+          UIManager.getViewManagerConfig(RNSketchCanvas).Commands.newPath,
           [
             this._path.id,
             processColor(this._path.color),
@@ -180,7 +180,7 @@ class SketchCanvas extends React.Component {
         )
         UIManager.dispatchViewManagerCommand(
           this._handle,
-          UIManager.RNSketchCanvas.Commands.addPoint,
+          UIManager.getViewManagerConfig(RNSketchCanvas).Commands.addPoint,
           [
             parseFloat((gestureState.x0 - this._offset.x).toFixed(2) * this._screenScale),
             parseFloat((gestureState.y0 - this._offset.y).toFixed(2) * this._screenScale)
@@ -193,7 +193,7 @@ class SketchCanvas extends React.Component {
       onPanResponderMove: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
         if (this._path) {
-          UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPoint, [
+          UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.addPoint, [
             parseFloat((gestureState.moveX - this._offset.x).toFixed(2) * this._screenScale),
             parseFloat((gestureState.moveY - this._offset.y).toFixed(2) * this._screenScale)
           ])
@@ -208,7 +208,7 @@ class SketchCanvas extends React.Component {
           this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })
           this._paths.push({ path: this._path, size: this._size, drawer: this.props.user })
         }
-        UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, [])
+        UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.endPath, [])
       },
 
       onShouldBlockNativeResponder: (evt, gestureState) => {
@@ -255,9 +255,9 @@ class SketchCanvas extends React.Component {
   }
 }
 
-SketchCanvas.MAIN_BUNDLE = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.MainBundlePath : '';
-SketchCanvas.DOCUMENT = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSDocumentDirectory : '';
-SketchCanvas.LIBRARY = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSLibraryDirectory : '';
-SketchCanvas.CACHES = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSCachesDirectory : '';
+SketchCanvas.MAIN_BUNDLE = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.MainBundlePath : '';
+SketchCanvas.DOCUMENT = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.NSDocumentDirectory : '';
+SketchCanvas.LIBRARY = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.NSLibraryDirectory : '';
+SketchCanvas.CACHES = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.NSCachesDirectory : '';
 
 module.exports = SketchCanvas;

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -162,6 +162,7 @@ class SketchCanvas extends React.Component {
 
       onPanResponderGrant: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
+        if (gestureState.numberActiveTouches > 1) return
         const e = evt.nativeEvent
         this._offset = { x: e.pageX - e.locationX, y: e.pageY - e.locationY }
         this._path = {

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -113,7 +113,7 @@ class SketchCanvas extends React.Component {
   clear() {
     this._paths = []
     this._path = null
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.clear, [])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.clear, [])
   }
 
   undo() {
@@ -130,7 +130,7 @@ class SketchCanvas extends React.Component {
         const coor = p.split(',').map(pp => parseFloat(pp).toFixed(2))
         return `${coor[0] * this._screenScale * this._size.width / data.size.width},${coor[1] * this._screenScale * this._size.height / data.size.height}`;
       })
-      UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPath, [
+      UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.addPath, [
         data.path.id, processColor(data.path.color), data.path.width * this._screenScale, pathData
       ])
     } else {
@@ -140,11 +140,11 @@ class SketchCanvas extends React.Component {
 
   deletePath(id) {
     this._paths = this._paths.filter(p => p.path.id !== id)
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.deletePath, [id])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.deletePath, [id])
   }
 
   save(imageType, transparent, folder, filename, includeImage, includeText, cropToImageSize) {
-    UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.save, [imageType, folder, filename, transparent, includeImage, includeText, cropToImageSize])
+    UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.save, [imageType, folder, filename, transparent, includeImage, includeText, cropToImageSize])
   }
 
   getPaths() {
@@ -183,7 +183,7 @@ class SketchCanvas extends React.Component {
 
         UIManager.dispatchViewManagerCommand(
           this._handle,
-          UIManager.RNSketchCanvas.Commands.newPath,
+          UIManager.getViewManagerConfig(RNSketchCanvas).Commands.newPath,
           [
             this._path.id,
             processColor(this._path.color),
@@ -192,7 +192,7 @@ class SketchCanvas extends React.Component {
         )
         UIManager.dispatchViewManagerCommand(
           this._handle,
-          UIManager.RNSketchCanvas.Commands.addPoint,
+          UIManager.getViewManagerConfig(RNSketchCanvas).Commands.addPoint,
           [
             parseFloat((x).toFixed(2) * this._screenScale),
             parseFloat((y).toFixed(2) * this._screenScale)
@@ -216,7 +216,7 @@ class SketchCanvas extends React.Component {
           const x = parseFloat((gestureState.x0 + rotated_dx / this.props.scale - this._offset.x).toFixed(2));
           const y = parseFloat((gestureState.y0 + rotated_dy / this.props.scale - this._offset.y).toFixed(2));
 
-          UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPoint, [
+          UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.addPoint, [
             parseFloat(x * this._screenScale),
             parseFloat(y * this._screenScale)
           ])
@@ -232,7 +232,7 @@ class SketchCanvas extends React.Component {
           this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })
           this._paths.push({ path: this._path, size: this._size, drawer: this.props.user })
         }
-        UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, [])
+        UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.endPath, [])
       },
       onPanResponderTerminate: (evt, gestureState) => {
         // Another component has become the responder, so this gesture should be cancelled
@@ -241,7 +241,7 @@ class SketchCanvas extends React.Component {
           this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user });
           this._paths.push({ path: this._path, size: this._size, drawer: this.props.user });
         }
-        UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, []);
+        UIManager.dispatchViewManagerCommand(this._handle, UIManager.getViewManagerConfig(RNSketchCanvas).Commands.endPath, []);
       },
 
       onShouldBlockNativeResponder: (evt, gestureState) => {
@@ -288,9 +288,9 @@ class SketchCanvas extends React.Component {
   }
 }
 
-SketchCanvas.MAIN_BUNDLE = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.MainBundlePath : '';
-SketchCanvas.DOCUMENT = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSDocumentDirectory : '';
-SketchCanvas.LIBRARY = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSLibraryDirectory : '';
-SketchCanvas.CACHES = Platform.OS === 'ios' ? UIManager.RNSketchCanvas.Constants.NSCachesDirectory : '';
+SketchCanvas.MAIN_BUNDLE = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.MainBundlePath : '';
+SketchCanvas.DOCUMENT = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.NSDocumentDirectory : '';
+SketchCanvas.LIBRARY = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.NSLibraryDirectory : '';
+SketchCanvas.CACHES = Platform.OS === 'ios' ? UIManager.getViewManagerConfig(RNSketchCanvas).Constants.NSCachesDirectory : '';
 
 module.exports = SketchCanvas;

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -211,6 +211,15 @@ class SketchCanvas extends React.Component {
         }
         UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, [])
       },
+      onPanResponderTerminate: (evt, gestureState) => {
+        // Another component has become the responder, so this gesture should be cancelled
+        if (!this.props.touchEnabled) return;
+        if (this._path) {
+          this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user });
+          this._paths.push({ path: this._path, size: this._size, drawer: this.props.user });
+        }
+        UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.endPath, []);
+      },
 
       onShouldBlockNativeResponder: (evt, gestureState) => {
         return true;

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -33,6 +33,7 @@ class SketchCanvas extends React.Component {
     onStrokeEnd: PropTypes.func,
     onSketchSaved: PropTypes.func,
     user: PropTypes.string,
+    scale: PropTypes.number,
 
     touchEnabled: PropTypes.bool,
 
@@ -64,6 +65,7 @@ class SketchCanvas extends React.Component {
     onStrokeEnd: () => { },
     onSketchSaved: () => { },
     user: null,
+    scale: 1,
 
     touchEnabled: true,
 
@@ -194,11 +196,12 @@ class SketchCanvas extends React.Component {
       onPanResponderMove: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
         if (this._path) {
+          const x = parseFloat((gestureState.x0 + gestureState.dx / this.props.scale - this._offset.x).toFixed(2)),
+                y = parseFloat((gestureState.y0 + gestureState.dy / this.props.scale - this._offset.y).toFixed(2))
           UIManager.dispatchViewManagerCommand(this._handle, UIManager.RNSketchCanvas.Commands.addPoint, [
-            parseFloat((gestureState.moveX - this._offset.x).toFixed(2) * this._screenScale),
-            parseFloat((gestureState.moveY - this._offset.y).toFixed(2) * this._screenScale)
+            parseFloat(x * this._screenScale),
+            parseFloat(y * this._screenScale)
           ])
-          const x = parseFloat((gestureState.moveX - this._offset.x).toFixed(2)), y = parseFloat((gestureState.moveY - this._offset.y).toFixed(2))
           this._path.data.push(`${x},${y}`)
           this.props.onStrokeChanged(x, y)
         }

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -162,10 +162,10 @@ class SketchCanvas extends React.Component {
   componentWillMount() {
     this.panResponder = PanResponder.create({
       // Ask to be the responder:
-      onStartShouldSetPanResponder: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
-      onStartShouldSetPanResponderCapture: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
-      onMoveShouldSetPanResponder: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
-      onMoveShouldSetPanResponderCapture: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
+      onStartShouldSetPanResponder: (evt, gestureState) => this.props.touchEnabled && gestureState.numberActiveTouches === this.props.requiredTouches,
+      onStartShouldSetPanResponderCapture: (evt, gestureState) => this.props.touchEnabled && gestureState.numberActiveTouches === this.props.requiredTouches,
+      onMoveShouldSetPanResponder: (evt, gestureState) => this.props.touchEnabled && gestureState.numberActiveTouches === this.props.requiredTouches,
+      onMoveShouldSetPanResponderCapture: (evt, gestureState) => this.props.touchEnabled && gestureState.numberActiveTouches === this.props.requiredTouches,
 
       onPanResponderGrant: (evt, gestureState) => {
         if (!this.props.touchEnabled) return;

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -35,8 +35,8 @@ class SketchCanvas extends React.Component {
     user: PropTypes.string,
     scale: PropTypes.number,
     rotation: PropTypes.number,
-    startToDrawDelay: PropTypes.number,
     requiredTouches: PropTypes.number,
+
 
     touchEnabled: PropTypes.bool,
 
@@ -70,7 +70,6 @@ class SketchCanvas extends React.Component {
     user: null,
     scale: 1,
     rotation: 0,
-    startToDrawDelay: 0,
     requiredTouches: null,
 
     touchEnabled: true,
@@ -96,8 +95,6 @@ class SketchCanvas extends React.Component {
     this._offset = { x: 0, y: 0 }
     this._size = { width: 0, height: 0 }
     this._initialized = false
-    this.touchStartTime = 0;
-    this.isDrawing = false;
 
     this.state.text = this._processText(props.text ? props.text.map(t => Object.assign({}, t)) : null)
   }
@@ -162,55 +159,6 @@ class SketchCanvas extends React.Component {
     }
   }
 
-  validateDrawingState(evt, gestureState) {
-    if (this.props.startToDrawDelay === 0) {
-      if (!this.isDrawing) {
-        this.startDrawing(evt, gestureState);
-      }
-      return true;
-    }
-    if (this.isDrawing) {
-      return true;
-    }
-    if (this.touchStartTime + this.props.startToDrawDelay < new Date().getTime()) {
-      this.startDrawing(evt, gestureState);
-      return true;
-    }
-    return false;
-  }
-
-  startDrawing(evt, gestureState){
-    this.isDrawing = true;
-
-    this._path = {
-      id: parseInt(Math.random() * 100000000), color: this.props.strokeColor,
-      width: this.props.strokeWidth, data: []
-    }
-
-    const x = parseFloat((gestureState.x0 - this._offset.x).toFixed(2)),
-          y = parseFloat((gestureState.y0 - this._offset.y).toFixed(2))
-
-    UIManager.dispatchViewManagerCommand(
-      this._handle,
-      UIManager.RNSketchCanvas.Commands.newPath,
-      [
-        this._path.id,
-        processColor(this._path.color),
-        this._path.width * this._screenScale
-      ]
-    )
-    UIManager.dispatchViewManagerCommand(
-      this._handle,
-      UIManager.RNSketchCanvas.Commands.addPoint,
-      [
-        parseFloat(x * this._screenScale),
-        parseFloat(y * this._screenScale)
-      ]
-    )
-    this._path.data.push(`${x},${y}`)
-    this.props.onStrokeStart(x, y)
-  }
-
   componentWillMount() {
     this.panResponder = PanResponder.create({
       // Ask to be the responder:
@@ -225,15 +173,40 @@ class SketchCanvas extends React.Component {
         
         const e = evt.nativeEvent
         this._offset = { x: e.pageX - e.locationX, y: e.pageY - e.locationY }
-        
-        this.touchStartTime = new Date().getTime();
-        this.isDrawing = false;
+        this._path = {
+          id: parseInt(Math.random() * 100000000), color: this.props.strokeColor,
+          width: this.props.strokeWidth, data: []
+        }
+
+        const x = parseFloat((gestureState.x0 - this._offset.x).toFixed(2)),
+              y = parseFloat((gestureState.y0 - this._offset.y).toFixed(2))
+
+        UIManager.dispatchViewManagerCommand(
+          this._handle,
+          UIManager.RNSketchCanvas.Commands.newPath,
+          [
+            this._path.id,
+            processColor(this._path.color),
+            this._path.width * this._screenScale
+          ]
+        )
+        UIManager.dispatchViewManagerCommand(
+          this._handle,
+          UIManager.RNSketchCanvas.Commands.addPoint,
+          [
+            parseFloat((x).toFixed(2) * this._screenScale),
+            parseFloat((y).toFixed(2) * this._screenScale)
+          ]
+        )
+        this._path.data.push(`${x},${y}`)
+        this.props.onStrokeStart(x, y)
       },
       onPanResponderMove: (evt, gestureState) => {
         if (!this.props.touchEnabled) return;
         if (this.props.requiredTouches && gestureState.numberActiveTouches !== this.props.requiredTouches) return;
-        if (!this.validateDrawingState(evt, gestureState)) return;
+
         if (this._path) {
+
           const clockwiseRotationModifier = -1;
           const rotationAsRadians = this.props.rotation * (Math.PI / 180) * clockwiseRotationModifier;
 
@@ -254,7 +227,7 @@ class SketchCanvas extends React.Component {
       onPanResponderRelease: (evt, gestureState) => {
         if (!this.props.touchEnabled) return;
         if (this.props.requiredTouches && gestureState.numberActiveTouches !== this.props.requiredTouches) return;
-        if (!this.validateDrawingState(evt, gestureState)) return;
+
         if (this._path) {
           this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })
           this._paths.push({ path: this._path, size: this._size, drawer: this.props.user })

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -35,6 +35,7 @@ class SketchCanvas extends React.Component {
     user: PropTypes.string,
     scale: PropTypes.number,
     rotation: PropTypes.number,
+    startToDrawDelay: PropTypes.number,
 
     touchEnabled: PropTypes.bool,
 
@@ -68,6 +69,7 @@ class SketchCanvas extends React.Component {
     user: null,
     scale: 1,
     rotation: 0,
+    startToDrawDelay: 0,
 
     touchEnabled: true,
 
@@ -92,6 +94,8 @@ class SketchCanvas extends React.Component {
     this._offset = { x: 0, y: 0 }
     this._size = { width: 0, height: 0 }
     this._initialized = false
+    this.touchStartTime = 0;
+    this.isDrawing = false;
 
     this.state.text = this._processText(props.text ? props.text.map(t => Object.assign({}, t)) : null)
   }
@@ -156,6 +160,55 @@ class SketchCanvas extends React.Component {
     }
   }
 
+  validateDrawingState(evt, gestureState) {
+    if (this.props.startToDrawDelay === 0) {
+      if (!this.isDrawing) {
+        this.startDrawing(evt, gestureState);
+      }
+      return true;
+    }
+    if (this.isDrawing) {
+      return true;
+    }
+    if (this.touchStartTime + this.props.startToDrawDelay < new Date().getTime()) {
+      this.startDrawing(evt, gestureState);
+      return true;
+    }
+    return false;
+  }
+
+  startDrawing(evt, gestureState){
+    this.isDrawing = true;
+
+    this._path = {
+      id: parseInt(Math.random() * 100000000), color: this.props.strokeColor,
+      width: this.props.strokeWidth, data: []
+    }
+
+    const x = parseFloat((gestureState.x0 - this._offset.x).toFixed(2)),
+          y = parseFloat((gestureState.y0 - this._offset.y).toFixed(2))
+
+    UIManager.dispatchViewManagerCommand(
+      this._handle,
+      UIManager.RNSketchCanvas.Commands.newPath,
+      [
+        this._path.id,
+        processColor(this._path.color),
+        this._path.width * this._screenScale
+      ]
+    )
+    UIManager.dispatchViewManagerCommand(
+      this._handle,
+      UIManager.RNSketchCanvas.Commands.addPoint,
+      [
+        parseFloat(x * this._screenScale),
+        parseFloat(y * this._screenScale)
+      ]
+    )
+    this._path.data.push(`${x},${y}`)
+    this.props.onStrokeStart(x, y)
+  }
+
   componentWillMount() {
     this.panResponder = PanResponder.create({
       // Ask to be the responder:
@@ -167,40 +220,17 @@ class SketchCanvas extends React.Component {
       onPanResponderGrant: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
         if (gestureState.numberActiveTouches > 1) return
+        
         const e = evt.nativeEvent
         this._offset = { x: e.pageX - e.locationX, y: e.pageY - e.locationY }
-        this._path = {
-          id: parseInt(Math.random() * 100000000), color: this.props.strokeColor,
-          width: this.props.strokeWidth, data: []
-        }
-
-        const x = parseFloat((gestureState.x0 - this._offset.x).toFixed(2)),
-              y = parseFloat((gestureState.y0 - this._offset.y).toFixed(2))
-
-        UIManager.dispatchViewManagerCommand(
-          this._handle,
-          UIManager.RNSketchCanvas.Commands.newPath,
-          [
-            this._path.id,
-            processColor(this._path.color),
-            this._path.width * this._screenScale
-          ]
-        )
-        UIManager.dispatchViewManagerCommand(
-          this._handle,
-          UIManager.RNSketchCanvas.Commands.addPoint,
-          [
-            parseFloat((x).toFixed(2) * this._screenScale),
-            parseFloat((y).toFixed(2) * this._screenScale)
-          ]
-        )
-        this._path.data.push(`${x},${y}`)
-        this.props.onStrokeStart(x, y)
+        
+        this.touchStartTime = new Date().getTime();
+        this.isDrawing = false;
       },
       onPanResponderMove: (evt, gestureState) => {
-        if (!this.props.touchEnabled) return
+        if (!this.props.touchEnabled) return;
+        if (!this.validateDrawingState(evt, gestureState)) return;
         if (this._path) {
-
           const clockwiseRotationModifier = -1;
           const rotationAsRadians = this.props.rotation * (Math.PI / 180) * clockwiseRotationModifier;
 
@@ -220,6 +250,7 @@ class SketchCanvas extends React.Component {
       },
       onPanResponderRelease: (evt, gestureState) => {
         if (!this.props.touchEnabled) return
+        if (!this.validateDrawingState(evt, gestureState)) return;
         if (this._path) {
           this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })
           this._paths.push({ path: this._path, size: this._size, drawer: this.props.user })

--- a/src/SketchCanvas.js
+++ b/src/SketchCanvas.js
@@ -36,6 +36,7 @@ class SketchCanvas extends React.Component {
     scale: PropTypes.number,
     rotation: PropTypes.number,
     startToDrawDelay: PropTypes.number,
+    requiredTouches: PropTypes.number,
 
     touchEnabled: PropTypes.bool,
 
@@ -70,6 +71,7 @@ class SketchCanvas extends React.Component {
     scale: 1,
     rotation: 0,
     startToDrawDelay: 0,
+    requiredTouches: null,
 
     touchEnabled: true,
 
@@ -212,14 +214,14 @@ class SketchCanvas extends React.Component {
   componentWillMount() {
     this.panResponder = PanResponder.create({
       // Ask to be the responder:
-      onStartShouldSetPanResponder: (evt, gestureState) => true,
-      onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
-      onMoveShouldSetPanResponder: (evt, gestureState) => true,
-      onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onStartShouldSetPanResponder: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
+      onStartShouldSetPanResponderCapture: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
+      onMoveShouldSetPanResponder: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
+      onMoveShouldSetPanResponderCapture: (evt, gestureState) => !this.props.requiredTouches || gestureState.numberActiveTouches === this.props.requiredTouches,
 
       onPanResponderGrant: (evt, gestureState) => {
-        if (!this.props.touchEnabled) return
-        if (gestureState.numberActiveTouches > 1) return
+        if (!this.props.touchEnabled) return;
+        if (this.props.requiredTouches && gestureState.numberActiveTouches !== this.props.requiredTouches) return;
         
         const e = evt.nativeEvent
         this._offset = { x: e.pageX - e.locationX, y: e.pageY - e.locationY }
@@ -229,6 +231,7 @@ class SketchCanvas extends React.Component {
       },
       onPanResponderMove: (evt, gestureState) => {
         if (!this.props.touchEnabled) return;
+        if (this.props.requiredTouches && gestureState.numberActiveTouches !== this.props.requiredTouches) return;
         if (!this.validateDrawingState(evt, gestureState)) return;
         if (this._path) {
           const clockwiseRotationModifier = -1;
@@ -249,7 +252,8 @@ class SketchCanvas extends React.Component {
         }
       },
       onPanResponderRelease: (evt, gestureState) => {
-        if (!this.props.touchEnabled) return
+        if (!this.props.touchEnabled) return;
+        if (this.props.requiredTouches && gestureState.numberActiveTouches !== this.props.requiredTouches) return;
         if (!this.validateDrawingState(evt, gestureState)) return;
         if (this._path) {
           this.props.onStrokeEnd({ path: this._path, size: this._size, drawer: this.props.user })


### PR DESCRIPTION
### Version 0.9.0
Upgrade master by merging in a couple notable PRs:

1. iOS Memory leak fix for 

`git pull https://github.com/crossfield/react-native-sketch-canvas fix-ios-memory-leak`

2. Fix iOS onPathsChange not firing on iOS after update 0.7.0

`git pull  https://github.com/hugpointgames/react-native-sketch-canvas 95-fix-on-paths-change`

3. Readme Update for Base64 image

`git pull [https://github.com/johannesschirrmeister/react-native-sketch-canvas](https://github.com/johannesschirrmeister/react-native-sketch-canvas/tree/) patch-1`

4. Add support for rotated canvases, scale, and limit touch event to 1 touch

`git pull [https://github.com/adento/react-native-sketch-canvas](https://github.com/adento/react-native-sketch-canvas)`

5. Fix depreciated UIManager to getViewManagerConfig

`git pull [https://github.com/jramalho/react-native-sketch-canvas](https://github.com/jramalho/react-native-sketch-canvas)`

6. Fix LocalSourceImage typescript def

`git pull [https://github.com/nielsmadan/react-native-sketch-canvas patch-1](https://github.com/nielsmadan/react-native-sketch-canvas/tree/patch-1)`